### PR TITLE
Solving issues with broadcast error in android 

### DIFF
--- a/android/.project
+++ b/android/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1619667401869</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/android/.settings/org.eclipse.buildship.core.prefs
+++ b/android/.settings/org.eclipse.buildship.core.prefs
@@ -1,11 +1,11 @@
 arguments=
 auto.sync=false
 build.scans.enabled=false
-connection.gradle.distribution=GRADLE_DISTRIBUTION(VERSION(5.4))
+connection.gradle.distribution=GRADLE_DISTRIBUTION(VERSION(6.8))
 connection.project.dir=
 eclipse.preferences.version=1
 gradle.user.home=
-java.home=
+java.home=/Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home
 jvm.arguments=
 offline.mode=false
 override.workspace.settings=true

--- a/android/src/main/java/com/simplegeofencing/reactnative/EnterZoneService.java
+++ b/android/src/main/java/com/simplegeofencing/reactnative/EnterZoneService.java
@@ -1,0 +1,67 @@
+ackage com.simplegeofencing.reactnative;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.content.Context;
+import android.content.Intent;
+import android.graphics.Color;
+import android.os.Build;
+import android.os.Bundle;
+import android.util.Log;
+
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+import androidx.core.app.NotificationCompat;
+
+import com.facebook.react.HeadlessJsTaskService;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.jstasks.HeadlessJsTaskConfig;
+
+public class EnterZoneService extends HeadlessJsTaskService {
+    @Override
+    public void onCreate() {
+            super.onCreate();
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+                startMyOwnForeground();
+            else
+                startForeground(1, new Notification());
+        }
+
+        @RequiresApi(api = Build.VERSION_CODES.O)
+        private void startMyOwnForeground(){
+            String NOTIFICATION_CHANNEL_ID = "com.example.simpleapp";
+            String channelName = "My Background Service";
+            NotificationChannel chan = new NotificationChannel(NOTIFICATION_CHANNEL_ID, channelName, NotificationManager.IMPORTANCE_NONE);
+            chan.setLightColor(Color.BLUE);
+            chan.setLockscreenVisibility(Notification.VISIBILITY_PRIVATE);
+            NotificationManager manager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+            assert manager != null;
+            manager.createNotificationChannel(chan);
+
+            NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID);
+            Notification notification = notificationBuilder.setOngoing(true)
+                    .setContentTitle("App is running in background")
+                    .setPriority(NotificationManager.IMPORTANCE_MIN)
+                    .setCategory(Notification.CATEGORY_SERVICE)
+                    .build();
+            startForeground(2, notification);
+        }
+
+    @Override
+    protected @Nullable
+    HeadlessJsTaskConfig getTaskConfig(Intent intent) {
+        Bundle extras = intent.getExtras();
+        if(extras == null){
+            extras = new Bundle();
+        }
+        Log.i("MonitorUpdate: extras", "remainingTime: " + extras.getInt("remainingTime"));
+        return new HeadlessJsTaskConfig(
+                "enterZone",
+                Arguments.fromBundle(extras),
+                extras.getInt("duration", 50000000), // timeout for the task
+                true // optional: defines whether or not  the task is allowed in foreground. Default is false
+        );
+
+    }
+}

--- a/android/src/main/java/com/simplegeofencing/reactnative/ExitZoneService.java
+++ b/android/src/main/java/com/simplegeofencing/reactnative/ExitZoneService.java
@@ -1,6 +1,5 @@
 package com.simplegeofencing.reactnative;
 
-
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
@@ -19,8 +18,7 @@ import com.facebook.react.HeadlessJsTaskService;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.jstasks.HeadlessJsTaskConfig;
 
-
-public class MonitorUpdateService extends HeadlessJsTaskService {
+public class ExitZoneService extends HeadlessJsTaskService {
     @Override
     public void onCreate() {
         super.onCreate();
@@ -53,16 +51,17 @@ public class MonitorUpdateService extends HeadlessJsTaskService {
     @Override
     protected @Nullable
     HeadlessJsTaskConfig getTaskConfig(Intent intent) {
-            Bundle extras = intent.getExtras();
-            if(extras == null){
-                extras = new Bundle();
-            }
-            Log.i("MonitorUpdate: extras", "remainingTime: " + extras.getInt("remainingTime"));
-            return new HeadlessJsTaskConfig(
-                    "leftMonitoringBorderWithDuration",
-                    Arguments.fromBundle(extras),
-                    extras.getInt("duration", 50000000), // timeout for the task
-                    true // optional: defines whether or not  the task is allowed in foreground. Default is false
-            );
+        Bundle extras = intent.getExtras();
+        if(extras == null){
+            extras = new Bundle();
+        }
+        Log.i("MonitorUpdate: extras", "remainingTime: " + extras.getInt("remainingTime"));
+        return new HeadlessJsTaskConfig(
+                "exitZone",
+                Arguments.fromBundle(extras),
+                extras.getInt("duration", 50000000),// timeout for the task
+                true // optional: defines whether or not  the task is allowed in foreground. Default is false
+        );
+
     }
 }

--- a/android/src/main/java/com/simplegeofencing/reactnative/GeofenceTransitionsBroadcastReceiver.java
+++ b/android/src/main/java/com/simplegeofencing/reactnative/GeofenceTransitionsBroadcastReceiver.java
@@ -15,13 +15,13 @@ import android.graphics.BitmapFactory;
 import android.os.Build;
 import android.os.Handler;
 import android.preference.PreferenceManager;
-import android.support.v4.app.NotificationCompat;
-import android.support.v4.app.NotificationManagerCompat;
-import android.support.v4.content.LocalBroadcastManager;
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import android.text.TextUtils;
 import android.util.Log;
 import android.widget.Toast;
-
+import android.content.res.Resources;
 import com.google.android.gms.location.Geofence;
 import com.google.android.gms.location.GeofencingEvent;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -97,6 +97,8 @@ public class GeofenceTransitionsBroadcastReceiver extends BroadcastReceiver {
                     Geofence geofence = geofencesWithoutMonitor.get(0);
                     String title = intent.getStringExtra("notifyEnterStringTitle");
                     String description = intent.getStringExtra("notifyEnterStringDescription");
+                    String smallIcon = intent.getStringExtra("notifyEnterStringSmallIcon");
+
                     ArrayList<String> geofenceValues = intent.getStringArrayListExtra("geofenceValues");
                     ArrayList<String> geofenceKeys = intent.getStringArrayListExtra("geofenceKeys");
                     int index = geofenceKeys.indexOf(geofence.getRequestId());
@@ -110,6 +112,7 @@ public class GeofenceTransitionsBroadcastReceiver extends BroadcastReceiver {
                     postNotification(
                             title,
                             description,
+                            smallIcon,
                             intent.getStringExtra("notifyChannelStringTitle"),
                             intent.getStringExtra("notifyChannelStringDescription"),
                             intent
@@ -125,6 +128,7 @@ public class GeofenceTransitionsBroadcastReceiver extends BroadcastReceiver {
                     Geofence geofence = geofencesWithoutMonitor.get(0);
                     String title = intent.getStringExtra("notifyExitStringTitle");
                     String description = intent.getStringExtra("notifyExitStringDescription");
+                    String smallIcon = intent.getStringExtra("notifyExitStringSmallIcon");
                     ArrayList<String> geofenceValues = intent.getStringArrayListExtra("geofenceValues");
                     ArrayList<String> geofenceKeys = intent.getStringArrayListExtra("geofenceKeys");
                     int index = geofenceKeys.indexOf(geofence.getRequestId());
@@ -138,6 +142,7 @@ public class GeofenceTransitionsBroadcastReceiver extends BroadcastReceiver {
                     postNotification(
                             title,
                             description,
+                            smallIcon,
                             intent.getStringExtra("notifyChannelStringTitle"),
                             intent.getStringExtra("notifyChannelStringDescription"),
                             intent
@@ -199,6 +204,7 @@ public class GeofenceTransitionsBroadcastReceiver extends BroadcastReceiver {
     */
     private NotificationCompat.Builder getNotificationBuilder(String title,
                                                               String content,
+                                                              String smallIcon,
                                                               String channelTitle,
                                                               String channelDescription,
                                                               Intent pIntent
@@ -211,11 +217,15 @@ public class GeofenceTransitionsBroadcastReceiver extends BroadcastReceiver {
         //PendingIntent contentIntent = PendingIntent.getBroadcast(this.mContext, NOTIFICATION_ID, intent, PendingIntent.FLAG_UPDATE_CURRENT);
 
         //Build notification
+        Resources res = this.mContext.getResources();
+        String packageName = this.mContext.getPackageName();
+        int smallIconDrawable = res.getIdentifier(smallIcon, "drawable", packageName);
+
         NotificationCompat.Builder notification = new NotificationCompat.Builder(this.mContext, CHANNEL_ID)
                 .setContentTitle(title)
                 .setStyle(new NotificationCompat.BigTextStyle().bigText(content))
                 .setContentText(content)
-                .setSmallIcon(this.mContext.getApplicationInfo().icon)
+                .setSmallIcon((smallIconDrawable != 0) ? smallIconDrawable : this.mContext.getApplicationInfo().icon)
                 .setContentIntent(contentIntent)
                 .setAutoCancel(true);
 
@@ -238,6 +248,7 @@ public class GeofenceTransitionsBroadcastReceiver extends BroadcastReceiver {
 
     public void postNotification(String title,
                                  String content,
+                                 String smallIcon,
                                  String channelTitle,
                                  String channelDescription,
                                  Intent pIntent
@@ -246,7 +257,7 @@ public class GeofenceTransitionsBroadcastReceiver extends BroadcastReceiver {
 
         // notificationId is a unique int for each notification that you must define
         notificationManager.notify(NOTIFICATION_TAG, NOTIFICATION_ID,
-                getNotificationBuilder(title, content, channelTitle, channelDescription, pIntent).build());
+                getNotificationBuilder(title, content, smallIcon, channelTitle, channelDescription, pIntent).build());
     }
     public void clearNotification(){
         NotificationManagerCompat notificationManager = NotificationManagerCompat.from(this.mContext);

--- a/android/src/main/java/com/simplegeofencing/reactnative/RNSimpleNativeGeofencingModule.java
+++ b/android/src/main/java/com/simplegeofencing/reactnative/RNSimpleNativeGeofencingModule.java
@@ -1,5 +1,6 @@
 package com.simplegeofencing.reactnative;
 
+import android.app.Activity;
 import android.app.AlarmManager;
 import android.app.NotificationManager;
 import android.app.NotificationChannel;
@@ -8,25 +9,27 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.content.SharedPreferences;
-import android.graphics.BitmapFactory;
+
 import android.os.Build;
-import android.preference.PreferenceManager;
-import android.support.annotation.NonNull;
-//import android.support.v4.app.NotificationCompat;
-import android.support.v4.app.NotificationCompat;
-import android.support.v4.app.NotificationManagerCompat;
-import android.support.v4.content.LocalBroadcastManager;
+
 import android.util.Log;
 
+import androidx.annotation.NonNull;
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+
 import com.facebook.react.HeadlessJsTaskService;
+import com.facebook.react.bridge.CatalystInstance;
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.modules.core.DeviceEventManagerModule;
+import com.facebook.react.bridge.WritableNativeArray;
 import com.google.android.gms.location.Geofence;
 import com.google.android.gms.location.GeofencingRequest;
 import com.google.android.gms.location.LocationServices;
@@ -58,7 +61,7 @@ public class RNSimpleNativeGeofencingModule extends ReactContextBaseJavaModule {
   private String[] notifyEnterString = new String[2];
   private String[] notifyExitString = new String[2];
   private Long mStartTime;
-  private int mDuration;
+  private int mDuration = 300000;
   private LocalBroadcastReceiver mLocalBroadcastReceiver;
   private LocalBroadcastManager mLocalBroadcastManager;
   private static final String PREFERENCE_LAST_NOTIF_ID = "PREFERENCE_LAST_NOTIF_ID";
@@ -67,6 +70,8 @@ public class RNSimpleNativeGeofencingModule extends ReactContextBaseJavaModule {
   private static final String NOTIFICATION_TAG = "GeofenceNotification";
   private static final int NOTIFICATION_ID_START = 1;
   private static final int NOTIFICATION_ID_STOP = 150;
+  private boolean test = false;
+
 
 
   public RNSimpleNativeGeofencingModule(ReactApplicationContext reactContext) {
@@ -81,6 +86,7 @@ public class RNSimpleNativeGeofencingModule extends ReactContextBaseJavaModule {
     this.geofenceKeys = new ArrayList<String>();
     this.geofenceValues = new ArrayList<String>();
   }
+
 
   @Override
   public String getName() {
@@ -149,13 +155,12 @@ public class RNSimpleNativeGeofencingModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void addGeofences(
           ReadableArray geofenceArray,
-          int duration,
           Callback failCallback)
   {
     //Add geohashes
     for (int i = 0; i < geofenceArray.size(); i++) {
       ReadableMap geofence = geofenceArray.getMap(i);
-      addGeofence(geofence, duration);
+      addGeofence(geofence);
     }
     //Start Monitoring
     startMonitoring(failCallback);
@@ -163,38 +168,36 @@ public class RNSimpleNativeGeofencingModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void updateGeofences(
-          ReadableArray geofenceArray,
-          int duration
+          ReadableArray geofenceArray
   ){
     mGeofenceList.clear();
     silentStopMonitoring();
     //Add geohashes
     for (int i = 0; i < geofenceArray.size(); i++) {
       ReadableMap geofence = geofenceArray.getMap(i);
-      addGeofence(geofence, duration);
+      addGeofence(geofence);
     }
     silentStartMonitoring();
   }
 
   @ReactMethod
-  public void addGeofence(ReadableMap geofenceObject, int duration) {
+  public void addGeofence(ReadableMap geofenceObject) {
     mGeofenceList.add(new Geofence.Builder()
-      .setRequestId(geofenceObject.getString("key"))
-      .setCircularRegion(
-        geofenceObject.getDouble("latitude"),
-        geofenceObject.getDouble("longitude"),
-        geofenceObject.getInt("radius")
-      )
-      .setExpirationDuration(duration)
-      .setTransitionTypes(Geofence.GEOFENCE_TRANSITION_ENTER |
-        Geofence.GEOFENCE_TRANSITION_EXIT)
-      .build());
+            .setRequestId(geofenceObject.getString("key"))
+            .setCircularRegion(
+                    geofenceObject.getDouble("latitude"),
+                    geofenceObject.getDouble("longitude"),
+                    geofenceObject.getInt("radius")
+            )
+            .setExpirationDuration(Geofence.NEVER_EXPIRE)
+            .setTransitionTypes(Geofence.GEOFENCE_TRANSITION_ENTER |
+                    Geofence.GEOFENCE_TRANSITION_EXIT)
+            .build());
 
     if(geofenceObject.hasKey("value")){
       geofenceKeys.add(geofenceObject.getString("key"));
       geofenceValues.add(geofenceObject.getString("value"));
     }
-    mDuration = duration;
     Log.i(TAG, "Added geofence: Lat " + geofenceObject.getDouble("latitude") + " Long " + geofenceObject.getDouble("longitude"));
   }
 
@@ -203,46 +206,50 @@ public class RNSimpleNativeGeofencingModule extends ReactContextBaseJavaModule {
     //Context removed by Listeners
     //if (ContextCompat.checkSelfPermission(this.reactContext, Manifest.permission.ACCESS_FINE_LOCATION)
     //        != PackageManager.PERMISSION_GRANTED){
-      mGeofencingClient.addGeofences(getGeofencingRequest(), getGeofencePendingIntent())
-        .addOnSuccessListener(new OnSuccessListener<Void>() {
-          @Override
-          public void onSuccess(Void aVoid) {
-            Log.i(TAG, "Added Geofences");
-            notifyNow("start");
-            mStartTime = System.currentTimeMillis();
-            mLocalBroadcastManager.registerReceiver(
-                    mLocalBroadcastReceiver, new IntentFilter("outOfMonitorGeofence"));
+    mGeofencingClient.addGeofences(getGeofencingRequest(), getGeofencePendingIntent())
+            .addOnSuccessListener(new OnSuccessListener<Void>() {
+              @Override
+              public void onSuccess(Void aVoid) {
+                Log.i(TAG, "Added Geofences");
+                notifyNow("start");
+                mStartTime = System.currentTimeMillis();
+                mLocalBroadcastManager.registerReceiver(
+                        mLocalBroadcastReceiver, new IntentFilter("outOfMonitorGeofence"));
+                mLocalBroadcastManager.registerReceiver(
+                        mLocalBroadcastReceiver, new IntentFilter("EnterZone"));
+                mLocalBroadcastManager.registerReceiver(
+                        mLocalBroadcastReceiver, new IntentFilter("ExitZone"));
 
-            //Launch service to notify after timeout
-            if(notifyStop == true){
-              Intent notificationIntent = new Intent(reactContext, ShowTimeoutNotification.class);
-              notificationIntent.putExtra("notifyChannelStringTitle", notifyChannelString[0]);
-              notificationIntent.putExtra("notifyChannelStringDescription", notifyChannelString[1]);
-              notificationIntent.putExtra("notifyStringTitle", notifyStopString[0]);
-              notificationIntent.putExtra("notifyStringDescription", notifyStopString[1]);
+                //Launch service to notify after timeout
+                if(notifyStop){
+                  Intent notificationIntent = new Intent(reactContext, ShowTimeoutNotification.class);
+                  notificationIntent.putExtra("notifyChannelStringTitle", notifyChannelString[0]);
+                  notificationIntent.putExtra("notifyChannelStringDescription", notifyChannelString[1]);
+                  notificationIntent.putExtra("notifyStringTitle", notifyStopString[0]);
+                  notificationIntent.putExtra("notifyStringDescription", notifyStopString[1]);
 
-              PendingIntent contentIntent = PendingIntent.getService(reactContext, 0, notificationIntent,
-                      PendingIntent.FLAG_CANCEL_CURRENT);
+                  PendingIntent contentIntent = PendingIntent.getService(reactContext, 0, notificationIntent,
+                          PendingIntent.FLAG_CANCEL_CURRENT);
 
-              AlarmManager am = (AlarmManager) reactContext.getSystemService(Context.ALARM_SERVICE);
-              am.cancel(contentIntent);
-              if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.M){
-                am.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, System.currentTimeMillis()+mDuration, contentIntent);
-              }else{
-                am.setExact(AlarmManager.RTC_WAKEUP, System.currentTimeMillis()+mDuration, contentIntent);
+                  AlarmManager am = (AlarmManager) reactContext.getSystemService(Context.ALARM_SERVICE);
+                  am.cancel(contentIntent);
+                  if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.M){
+                    am.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, System.currentTimeMillis()+mDuration, contentIntent);
+                  }else{
+                    am.setExact(AlarmManager.RTC_WAKEUP, System.currentTimeMillis()+mDuration, contentIntent);
+                  }
+
+                }
+
               }
-
-            }
-
-          }
-        })
-        .addOnFailureListener(new OnFailureListener() {
-          @Override
-          public void onFailure(@NonNull Exception e) {
-            failCallback.invoke(e.getMessage());
-            Log.e(TAG, "Adding Geofences: " + e.getMessage());
-          }
-        });
+            })
+            .addOnFailureListener(new OnFailureListener() {
+              @Override
+              public void onFailure(@NonNull Exception e) {
+                failCallback.invoke(e.getMessage());
+                Log.e(TAG, "Adding Geofences: " + e.getMessage());
+              }
+            });
     //}
 
   }
@@ -271,36 +278,36 @@ public class RNSimpleNativeGeofencingModule extends ReactContextBaseJavaModule {
   public void stopMonitoring() {
     //Context removed by Listeners
     mGeofencingClient.removeGeofences(getGeofencePendingIntent())
-      .addOnSuccessListener(new OnSuccessListener<Void>() {
-        @Override
-        public void onSuccess(Void aVoid) {
-          Log.i(TAG, "Removed Geofences");
+            .addOnSuccessListener(new OnSuccessListener<Void>() {
+              @Override
+              public void onSuccess(Void aVoid) {
+                Log.i(TAG, "Removed Geofences");
 
-          notifyNow("stop");
-          mLocalBroadcastManager.unregisterReceiver(mLocalBroadcastReceiver);
-          if(notifyStop == true){
-            Intent notificationIntent = new Intent(reactContext, ShowTimeoutNotification.class);
-            notificationIntent.putExtra("notifyChannelStringTitle", notifyChannelString[0]);
-            notificationIntent.putExtra("notifyChannelStringDescription", notifyChannelString[1]);
-            notificationIntent.putExtra("notifyStringTitle", notifyStopString[0]);
-            notificationIntent.putExtra("notifyStringDescription", notifyStopString[1]);
+                notifyNow("stop");
+                mLocalBroadcastManager.unregisterReceiver(mLocalBroadcastReceiver);
+                if(notifyStop == true){
+                  Intent notificationIntent = new Intent(reactContext, ShowTimeoutNotification.class);
+                  notificationIntent.putExtra("notifyChannelStringTitle", notifyChannelString[0]);
+                  notificationIntent.putExtra("notifyChannelStringDescription", notifyChannelString[1]);
+                  notificationIntent.putExtra("notifyStringTitle", notifyStopString[0]);
+                  notificationIntent.putExtra("notifyStringDescription", notifyStopString[1]);
 
-            PendingIntent contentIntent = PendingIntent.getService(reactContext, 0, notificationIntent,
-                    PendingIntent.FLAG_CANCEL_CURRENT);
+                  PendingIntent contentIntent = PendingIntent.getService(reactContext, 0, notificationIntent,
+                          PendingIntent.FLAG_CANCEL_CURRENT);
 
-            AlarmManager am = (AlarmManager) reactContext.getSystemService(Context.ALARM_SERVICE);
-            am.cancel(contentIntent);
-          }
+                  AlarmManager am = (AlarmManager) reactContext.getSystemService(Context.ALARM_SERVICE);
+                  am.cancel(contentIntent);
+                }
 
 
-        }
-      })
-      .addOnFailureListener(new OnFailureListener() {
-        @Override
-        public void onFailure(@NonNull Exception e) {
-          Log.e(TAG, "Removing Geofences: " + e.getMessage());
-        }
-      });
+              }
+            })
+            .addOnFailureListener(new OnFailureListener() {
+              @Override
+              public void onFailure(@NonNull Exception e) {
+                Log.e(TAG, "Removing Geofences: " + e.getMessage());
+              }
+            });
   }
 
   public void silentStopMonitoring() {
@@ -320,11 +327,6 @@ public class RNSimpleNativeGeofencingModule extends ReactContextBaseJavaModule {
             });
   }
 
-  @ReactMethod
-  public void testNotify(){
-    Log.i(TAG, "TestNotify Callback worked");
-    postNotification("TestNotify", "Callback worked", false);
-  }
 
   /*
     Helpfunctions
@@ -345,7 +347,7 @@ public class RNSimpleNativeGeofencingModule extends ReactContextBaseJavaModule {
     Intent intent = new Intent(this.getCurrentActivity(), GeofenceTransitionsBroadcastReceiver.class);
     // Add notification data
     intent.putExtra("notifyEnter", notifyEnter);
-    if(notifyEnter == true){
+    if(notifyEnter){
       intent.putExtra("notifyEnterStringTitle", notifyEnterString[0]);
       intent.putExtra("notifyEnterStringDescription", notifyEnterString[1]);
     }else{
@@ -353,7 +355,7 @@ public class RNSimpleNativeGeofencingModule extends ReactContextBaseJavaModule {
       intent.putExtra("notifyEnterStringDescription", "");
     }
     intent.putExtra("notifyExit", notifyExit);
-    if(notifyExit == true){
+    if(notifyExit){
       intent.putExtra("notifyExitStringTitle", notifyExitString[0]);
       intent.putExtra("notifyExitStringDescription", notifyExitString[1]);
     }else{
@@ -362,8 +364,6 @@ public class RNSimpleNativeGeofencingModule extends ReactContextBaseJavaModule {
     }
     intent.putExtra("notifyChannelStringTitle", notifyChannelString[0]);
     intent.putExtra("notifyChannelStringDescription", notifyChannelString[1]);
-    intent.putExtra("startTime", (Long) System.currentTimeMillis());
-    intent.putExtra("duration", mDuration);
     intent.putStringArrayListExtra("geofenceKeys", geofenceKeys);
     intent.putStringArrayListExtra("geofenceValues", geofenceValues);
     // We use FLAG_UPDATE_CURRENT so that we get the same pending intent back when
@@ -377,13 +377,13 @@ public class RNSimpleNativeGeofencingModule extends ReactContextBaseJavaModule {
        Notifications
     */
   private void notifyNow(String action){
-    if(action == "start"){
-      if(notifyStart == true){
+    if(action.equals("start")){
+      if(notifyStart){
         postNotification(notifyStartString[0], notifyStartString[1], true);
       }
     }
-    if(action == "stop"){
-      if(notifyStop == true){
+    if(action.equals("stop")){
+      if(notifyStop){
         postNotification(notifyStopString[0], notifyStopString[1], false);
       }
     }
@@ -441,19 +441,44 @@ public class RNSimpleNativeGeofencingModule extends ReactContextBaseJavaModule {
   public class LocalBroadcastReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
-      Long currentTime = System.currentTimeMillis();
-      int duration = intent.getIntExtra("duration", 3000);
-      Long startTime = intent.getLongExtra("startTime", System.currentTimeMillis());
-      int remainingTime = toIntExact(duration-(currentTime-startTime));
+      Log.i(TAG,intent.getAction());
       Log.i(TAG, "Broadcast received");
-      Log.i(TAG, "RemainingTimeReceiver: " + remainingTime);
-      Intent serviceIntent = new Intent(context, MonitorUpdateService.class);
-      serviceIntent.putExtra("remainingTime", remainingTime);
-      serviceIntent.putExtra("duration", duration);
-      serviceIntent.putExtra("startTime", startTime);
-      context.startService(serviceIntent);
-      HeadlessJsTaskService.acquireWakeLockNow(context);
 
+      if(intent.getAction().equals("EnterZone")){
+        Log.i(TAG, "In Zone");
+        Intent serviceIntent = new Intent(context, EnterZoneService.class);
+        serviceIntent.putExtra("duration", 50000000);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+          context.startForegroundService(serviceIntent);
+        }
+        else{
+          context.startService(serviceIntent);
+        }
+        HeadlessJsTaskService.acquireWakeLockNow(context);
+      }
+      else if (intent.getAction().equals("outOfMonitorGeofence")){
+          Log.i(TAG, "Out monitor");
+        Intent serviceIntent = new Intent(context, MonitorUpdateService.class);
+        serviceIntent.putExtra("duration", 50000000);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+          context.startForegroundService(serviceIntent);
+        }
+        else{
+          context.startService(serviceIntent);
+        }
+        HeadlessJsTaskService.acquireWakeLockNow(context);
+      }
+      else{
+        Intent serviceIntent = new Intent(context,ExitZoneService.class);
+        serviceIntent.putExtra("duration", 50000000);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+          context.startForegroundService(serviceIntent);
+        }
+        else{
+          context.startService(serviceIntent);
+        }
+        HeadlessJsTaskService.acquireWakeLockNow(context);
+      }
       //reactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
       //        .emit("outOfMonitorGeofence", remainingTime);
 


### PR DESCRIPTION
Adding more headless task for enter and leave, and adding a version check to validate if we can use start foreground service or the normal services since if we don't do it like this android blocks event in foreground since they are a broadcast